### PR TITLE
43 backend implement spotify api integration using client credentials flow and handle rate limits

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,10 +2,14 @@
 PORT=3000
 NODE_ENV=development
 
-# Spotify API Credentials
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
-SPOTIFY_REDIRECT_URI=http://localhost:3000/callback
+# Spotify API Credentials for Client Credentials Flow
+SPOTIFY_CLIENT_IDS=your_spotify_client_id1,your_spotify_client_id2
+SPOTIFY_CLIENT_SECRETS=your_spotify_client_secret1,your_spotify_client_secret2
+
+# Spotify API Credentials for OAuth (for future use)
+SPOTIFY_OAUTH_CLIENT_ID=your_spotify_oauth_client_id
+SPOTIFY_OAUTH_CLIENT_SECRET=your_spotify_oauth_client_secret
+SPOTIFY_REDIRECT_URI=http://localhost:3000/auth/spotify/callback
 
 # YouTube API Credentials
 YOUTUBE_API_KEYS=your_youtube_api_key1,your_youtube_api_key2
@@ -13,5 +17,5 @@ YOUTUBE_API_KEYS=your_youtube_api_key1,your_youtube_api_key2
 # Session Secret
 SESSION_SECRET=your_session_secret
 
-# MongoDB Connection (if using MongoDB)
+# MongoDB Connection
 MONGODB_URI=your_mongodb_connection_string

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -1,0 +1,108 @@
+// auth.js
+const express = require('express');
+const passport = require('passport');
+const SpotifyStrategy = require('passport-spotify').Strategy;
+const request = require('request'); // Consider using a modern HTTP client like axios or node-fetch
+
+const router = express.Router();
+
+// Serialize and deserialize user instances to and from the session
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((obj, done) => {
+  done(null, obj);
+});
+
+// Configure the Spotify strategy for use by Passport
+passport.use(
+  new SpotifyStrategy(
+    {
+      clientID: process.env.SPOTIFY_CLIENT_ID,
+      clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+      callbackURL: process.env.SPOTIFY_REDIRECT_URI,
+    },
+    (accessToken, refreshToken, expires_in, profile, done) => {
+      const user = {
+        spotifyId: profile.id,
+        displayName: profile.displayName,
+        photos: profile.photos,
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+        expiresIn: Date.now() + expires_in * 1000, // Convert expires_in to timestamp
+      };
+      return done(null, user);
+    }
+  )
+);
+
+// Authentication route for Spotify
+router.get(
+  '/auth/spotify',
+  passport.authenticate('spotify', {
+    scope: ['user-read-email', 'user-read-private'],
+    showDialog: true,
+  })
+);
+
+// Callback route
+router.get(
+  '/auth/spotify/callback',
+  passport.authenticate('spotify', { failureRedirect: '/login' }),
+  (req, res) => {
+    // Successful authentication
+    res.redirect('/dashboard');
+  }
+);
+
+// Logout route
+router.get('/logout', (req, res) => {
+  req.logout(() => {
+    res.redirect('/');
+  });
+});
+
+// Middleware to ensure user is authenticated
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+  res.redirect('/login'); // Redirect unauthenticated users to login
+}
+
+// Function to refresh the Spotify access token
+const axios = require('axios');
+
+function refreshSpotifyToken(refreshToken, callback) {
+  const authOptions = {
+    method: 'post',
+    url: 'https://accounts.spotify.com/api/token',
+    params: {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    },
+    headers: {
+      Authorization:
+        'Basic ' +
+        Buffer.from(
+          process.env.SPOTIFY_CLIENT_ID + ':' + process.env.SPOTIFY_CLIENT_SECRET
+        ).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  };
+
+  axios(authOptions)
+    .then((response) => {
+      const newAccessToken = response.data.access_token;
+      const newExpiresIn = Date.now() + response.data.expires_in * 1000;
+      callback(null, newAccessToken, newExpiresIn);
+    })
+    .catch((error) => {
+      console.error('Failed to refresh access token:', error.response.data);
+      callback(error, null, null);
+    });
+}
+
+// Export both the router and utility functions
+module.exports = { router, ensureAuthenticated, refreshSpotifyToken };

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const passport = require('passport');
 const SpotifyStrategy = require('passport-spotify').Strategy;
-const axios = require('axios'); // Use axios for HTTP requests
+const axios = require('axios');
 
 const router = express.Router();
 
@@ -15,12 +15,12 @@ passport.deserializeUser((obj, done) => {
   done(null, obj);
 });
 
-// Configure the Spotify strategy for use by Passport
+// Configure the Spotify strategy for use by Passport (OAuth)
 passport.use(
   new SpotifyStrategy(
     {
-      clientID: process.env.SPOTIFY_CLIENT_ID,
-      clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+      clientID: process.env.SPOTIFY_OAUTH_CLIENT_ID,
+      clientSecret: process.env.SPOTIFY_OAUTH_CLIENT_SECRET,
       callbackURL: process.env.SPOTIFY_REDIRECT_URI,
     },
     (accessToken, refreshToken, expires_in, profile, done) => {
@@ -41,7 +41,7 @@ passport.use(
 router.get(
   '/auth/spotify',
   passport.authenticate('spotify', {
-    scope: ['user-read-email', 'user-read-private'],
+    scope: ['user-read-email'],
     showDialog: true,
   })
 );
@@ -68,10 +68,10 @@ function ensureAuthenticated(req, res, next) {
   if (req.isAuthenticated()) {
     return next();
   }
-  res.redirect('/login'); // Redirect unauthenticated users to login
+  res.redirect('/auth/spotify'); // Redirect unauthenticated users to login
 }
 
-// Function to refresh the Spotify access token
+// Function to refresh the Spotify access token (OAuth)
 async function refreshSpotifyToken(refreshToken) {
   const authOptions = {
     method: 'post',
@@ -84,7 +84,7 @@ async function refreshSpotifyToken(refreshToken) {
       Authorization:
         'Basic ' +
         Buffer.from(
-          process.env.SPOTIFY_CLIENT_ID + ':' + process.env.SPOTIFY_CLIENT_SECRET
+          process.env.SPOTIFY_OAUTH_CLIENT_ID + ':' + process.env.SPOTIFY_OAUTH_CLIENT_SECRET
         ).toString('base64'),
       'Content-Type': 'application/x-www-form-urlencoded',
     },

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -52,7 +52,7 @@ router.get(
   passport.authenticate('spotify', { failureRedirect: '/login' }),
   (req, res) => {
     // Successful authentication
-    res.redirect('/dashboard');
+    res.redirect('/');
   }
 );
 

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const passport = require('passport');
 const SpotifyStrategy = require('passport-spotify').Strategy;
-const request = require('request'); // Consider using a modern HTTP client like axios or node-fetch
+const axios = require('axios'); // Use axios for HTTP requests
 
 const router = express.Router();
 
@@ -72,9 +72,7 @@ function ensureAuthenticated(req, res, next) {
 }
 
 // Function to refresh the Spotify access token
-const axios = require('axios');
-
-function refreshSpotifyToken(refreshToken, callback) {
+async function refreshSpotifyToken(refreshToken) {
   const authOptions = {
     method: 'post',
     url: 'https://accounts.spotify.com/api/token',
@@ -92,16 +90,15 @@ function refreshSpotifyToken(refreshToken, callback) {
     },
   };
 
-  axios(authOptions)
-    .then((response) => {
-      const newAccessToken = response.data.access_token;
-      const newExpiresIn = Date.now() + response.data.expires_in * 1000;
-      callback(null, newAccessToken, newExpiresIn);
-    })
-    .catch((error) => {
-      console.error('Failed to refresh access token:', error.response.data);
-      callback(error, null, null);
-    });
+  try {
+    const response = await axios(authOptions);
+    const newAccessToken = response.data.access_token;
+    const newExpiresIn = Date.now() + response.data.expires_in * 1000;
+    return { newAccessToken, newExpiresIn };
+  } catch (error) {
+    console.error('Failed to refresh access token:', error.response.data);
+    throw error;
+  }
 }
 
 // Export both the router and utility functions

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,8 +28,10 @@
     ]
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-rate-limit": "^7.4.1",
     "express-session": "^1.18.1",
     "passport": "^0.7.0",
     "passport-spotify": "^2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,10 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "express-session": "^1.18.1",
+    "passport": "^0.7.0",
+    "passport-spotify": "^2.0.0",
+    "request": "^2.88.2"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,50 +1,44 @@
-const fs = require('fs');
-const path = require('path');
-
-const NODE_ENV = process.env.NODE_ENV || 'development';
-
-const envFile = NODE_ENV === 'production' ? '.env.production' : '.env.development';
-
-// Load environment variables from the determined .env file
-const envPath = path.resolve(__dirname, envFile);
-
-// Check if the .env file exists
-if (fs.existsSync(envPath)) {
-  require('dotenv').config({ path: envPath });
-} else {
-  console.warn(`Environment file ${envFile} not found. Loading default .env`);
-  require('dotenv').config();
-}
+// server.js
+require('dotenv').config();
 
 const express = require('express');
+const session = require('express-session');
+const passport = require('passport');
+const { router: authRoutes } = require('./auth'); // Adjust the path if necessary
+const spotifyRoutes = require('./spotifyRoutes'); // Adjust the path if necessary
+const rateLimit = require('express-rate-limit');
+
 const app = express();
 
-const PORT = process.env.PORT || 3000;
-
-// Define a simple route
-app.get('/', (req, res) => {
-  res.send('Welcome to the Snyder App Backend');
+// Global rate limiter (e.g., max 1000 requests per 15 minutes per IP)
+const globalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 1000, // limit each IP to 1000 requests per windowMs
+  message: {
+    error: 'Too many requests, please try again later.',
+  },
 });
 
-const session = require('express-session');
+// Apply the global rate limiter to all requests
+app.use(globalLimiter);
 
 // Configure Express session
 app.use(
   session({
-    secret: process.env.SESSION_SECRET,
+    secret: process.env.SESSION_SECRET, // Ensure SESSION_SECRET is set in .env
     resave: false,
     saveUninitialized: false,
-    cookie: { secure: process.env.NODE_ENV === 'production' }, // Set to true if using HTTPS
+    cookie: {
+      secure: process.env.NODE_ENV === 'production', // Set to true in production
+      httpOnly: true, // Helps prevent XSS
+      maxAge: 24 * 60 * 60 * 1000, // 1 day
+    },
   })
 );
 
-const passport = require('passport');
-
+// Initialize Passport
 app.use(passport.initialize());
 app.use(passport.session());
-
-const { ensureAuthenticated, router: authRoutes } = require('./auth');
-const spotifyRoutes = require('./spotifyRoutes');
 
 // Use authentication routes
 app.use(authRoutes);
@@ -52,15 +46,13 @@ app.use(authRoutes);
 // Use Spotify data routes
 app.use(spotifyRoutes);
 
-app.get('/dashboard', ensureAuthenticated, (req, res) => {
-  res.json({
-    message: 'Welcome to your dashboard',
-    user: req.user, // Access authenticated user's information here
-  });
+// Define other routes
+app.get('/', (req, res) => {
+  res.send('Welcome to the Snyder App Backend');
 });
 
-
 // Start the server
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,10 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-// Determine the environment, default to 'development' if not set
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-// Determine the path to the appropriate .env file
 const envFile = NODE_ENV === 'production' ? '.env.production' : '.env.development';
 
 // Load environment variables from the determined .env file
@@ -21,13 +19,46 @@ if (fs.existsSync(envPath)) {
 const express = require('express');
 const app = express();
 
-// Set the port from environment variables or default to 3000
 const PORT = process.env.PORT || 3000;
 
 // Define a simple route
 app.get('/', (req, res) => {
   res.send('Welcome to the Snyder App Backend');
 });
+
+const session = require('express-session');
+
+// Configure Express session
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: { secure: process.env.NODE_ENV === 'production' }, // Set to true if using HTTPS
+  })
+);
+
+const passport = require('passport');
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+const { ensureAuthenticated, router: authRoutes } = require('./auth');
+const spotifyRoutes = require('./spotifyRoutes');
+
+// Use authentication routes
+app.use(authRoutes);
+
+// Use Spotify data routes
+app.use(spotifyRoutes);
+
+app.get('/dashboard', ensureAuthenticated, (req, res) => {
+  res.json({
+    message: 'Welcome to your dashboard',
+    user: req.user, // Access authenticated user's information here
+  });
+});
+
 
 // Start the server
 app.listen(PORT, () => {

--- a/backend/spotifyClientCredentials.js
+++ b/backend/spotifyClientCredentials.js
@@ -1,0 +1,89 @@
+// spotifyClientCredentials.js
+
+const axios = require('axios');
+
+// Extract client IDs and secrets from environment variables
+const clientIds = process.env.SPOTIFY_CLIENT_IDS.split(',');
+const clientSecrets = process.env.SPOTIFY_CLIENT_SECRETS.split(',');
+
+// Array to hold tokens for each client
+let tokens = [];
+let currentClientIndex = 0;
+
+// Function to get a new token for a specific client
+async function getNewToken(clientId, clientSecret) {
+  const authOptions = {
+    method: 'post',
+    url: 'https://accounts.spotify.com/api/token',
+    params: {
+      grant_type: 'client_credentials',
+    },
+    headers: {
+      Authorization:
+        'Basic ' +
+        Buffer.from(clientId + ':' + clientSecret).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  };
+
+  try {
+    const response = await axios(authOptions);
+    const accessToken = response.data.access_token;
+    const expiresIn = Date.now() + response.data.expires_in * 1000;
+    return { accessToken, expiresIn };
+  } catch (error) {
+    console.error('Failed to get access token:', error.response ? error.response.data : error);
+    throw error;
+  }
+}
+
+// Initialize tokens for all clients
+async function initializeTokens() {
+  tokens = await Promise.all(clientIds.map(async (clientId, index) => {
+    const clientSecret = clientSecrets[index];
+    const tokenData = await getNewToken(clientId, clientSecret);
+    return {
+      clientId,
+      clientSecret,
+      accessToken: tokenData.accessToken,
+      expiresIn: tokenData.expiresIn,
+    };
+  }));
+}
+
+// Function to get the next available access token
+async function getAccessToken() {
+  let tokenData = tokens[currentClientIndex];
+
+  // Check if token has expired or is about to expire
+  if (Date.now() >= tokenData.expiresIn - 1000) {
+    // Token expired, get a new one
+    try {
+      const newTokenData = await getNewToken(tokenData.clientId, tokenData.clientSecret);
+      tokenData.accessToken = newTokenData.accessToken;
+      tokenData.expiresIn = newTokenData.expiresIn;
+    } catch (error) {
+      console.error('Failed to refresh token:', error);
+      // Move to next client
+      currentClientIndex = (currentClientIndex + 1) % tokens.length;
+      return getAccessToken();
+    }
+  }
+
+  return tokenData.accessToken;
+}
+
+// Handle rate limit by switching to next client
+function handleRateLimit() {
+  currentClientIndex = (currentClientIndex + 1) % tokens.length;
+}
+
+// Initialize tokens at startup
+initializeTokens().catch(error => {
+  console.error('Failed to initialize tokens:', error);
+});
+
+module.exports = {
+  getAccessToken,
+  handleRateLimit,
+};

--- a/backend/spotifyRoutes.js
+++ b/backend/spotifyRoutes.js
@@ -1,0 +1,54 @@
+// spotifyRoutes.js
+const express = require('express');
+const request = require('request'); // Consider using axios or node-fetch for better promise support
+const { ensureAuthenticated, refreshSpotifyToken } = require('./auth'); // Adjust the path if necessary
+
+const router = express.Router();
+
+// Utility function to check token expiration
+function isTokenExpired(expiresIn) {
+  return Date.now() > expiresIn;
+}
+
+// Function to fetch user data from Spotify
+const axios = require('axios');
+
+function getSpotifyData(accessToken, res) {
+  const options = {
+    method: 'get',
+    url: 'https://api.spotify.com/v1/me',
+    headers: { Authorization: 'Bearer ' + accessToken },
+  };
+
+  axios(options)
+    .then((response) => {
+      res.json(response.data);
+    })
+    .catch((error) => {
+      res.status(error.response.status).json({ error: error.response.data });
+    });
+}
+
+// Route to fetch Spotify data
+router.get('/api/spotify-data', ensureAuthenticated, (req, res) => {
+  // Check if token has expired
+  if (isTokenExpired(req.user.expiresIn)) {
+    // Refresh the access token
+    refreshSpotifyToken(req.user.refreshToken, (err, newAccessToken, newExpiresIn) => {
+      if (err) {
+        return res.status(500).json({ error: 'Could not refresh access token' });
+      }
+      // Update the user's access token and expiration time
+      req.user.accessToken = newAccessToken;
+      req.user.expiresIn = newExpiresIn;
+      req.session.passport.user = req.user; // Update the session
+      // Proceed to make the API call
+      getSpotifyData(req.user.accessToken, res);
+    });
+  } else {
+    // Token is valid, proceed to make the API call
+    getSpotifyData(req.user.accessToken, res);
+  }
+});
+
+module.exports = router;

--- a/backend/spotifyRoutes.js
+++ b/backend/spotifyRoutes.js
@@ -2,64 +2,61 @@
 const express = require('express');
 const axios = require('axios');
 const rateLimit = require('express-rate-limit');
-const { ensureAuthenticated, refreshSpotifyToken } = require('./auth'); // Adjust the path if necessary
+const { getAccessToken, handleRateLimit } = require('./spotifyClientCredentials'); // Import the client credentials module
 
 const router = express.Router();
 
-// Rate limiter middleware (e.g., max 100 requests per 15 minutes per IP)
+// Rate limiter middleware (e.g., max 100 requests per 30 seconds per IP)
 const spotifyDataLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
+  windowMs: 30 * 1000, // 30 seconds
   max: 100, // limit each IP to 100 requests per windowMs
   message: {
     error: 'Too many requests, please try again later.',
   },
 });
 
-// Utility function to check token expiration
-function isTokenExpired(expiresIn) {
-  return Date.now() > expiresIn;
-}
-
-// Function to fetch user data from Spotify
-async function getSpotifyData(accessToken) {
+// Function to fetch data from Spotify API
+async function fetchSpotifyData(endpoint, params = {}) {
+  const accessToken = await getAccessToken();
   const options = {
     method: 'get',
-    url: 'https://api.spotify.com/v1/me',
+    url: `https://api.spotify.com/v1/${endpoint}`,
     headers: { Authorization: 'Bearer ' + accessToken },
+    params: params,
   };
 
-  const response = await axios(options);
-  return response.data;
-}
-
-// Route to fetch Spotify data
-router.get(
-  '/api/spotify-data',
-  ensureAuthenticated,
-  spotifyDataLimiter, // Apply rate limiting to this route
-  async (req, res) => {
-    try {
-      // Check if token has expired
-      if (isTokenExpired(req.user.expiresIn)) {
-        // Refresh the access token
-        const { newAccessToken, newExpiresIn } = await refreshSpotifyToken(
-          req.user.refreshToken
-        );
-
-        // Update the user's access token and expiration time
-        req.user.accessToken = newAccessToken;
-        req.user.expiresIn = newExpiresIn;
-        req.session.passport.user = req.user; // Update the session
-      }
-
-      // Token is valid, proceed to make the API call
-      const spotifyData = await getSpotifyData(req.user.accessToken);
-      res.json(spotifyData);
-    } catch (error) {
-      console.error('Error fetching Spotify data:', error);
-      res.status(500).json({ error: 'Failed to fetch Spotify data' });
+  try {
+    const response = await axios(options);
+    return response.data;
+  } catch (error) {
+    if (error.response && error.response.status === 429) {
+      // Rate limit exceeded, switch to next client
+      console.warn('Rate limit exceeded, switching to next client');
+      handleRateLimit();
+      // Retry the request
+      return fetchSpotifyData(endpoint, params);
+    } else {
+      throw error;
     }
   }
-);
+}
+
+// Route to search Spotify
+router.get('/api/spotify-search', spotifyDataLimiter, async (req, res) => {
+  const query = req.query.q;
+  const type = req.query.type || 'track';
+
+  if (!query) {
+    return res.status(400).json({ error: 'Missing required parameter: q' });
+  }
+
+  try {
+    const data = await fetchSpotifyData('search', { q: query, type: type, limit: 10 });
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching Spotify data:', error);
+    res.status(500).json({ error: 'Failed to fetch Spotify data' });
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
[Implement Spotify API integration using Client Credentials Flow](https://github.com/1varunvc/snyder/commit/e9a243f6923851b8caec7c02178c0389d86f9bd8) 

- Add `spotifyClientCredentials.js` to manage Spotify bearer tokens for Client Credentials Flow.
- Update `.env.example` to include multiple Spotify client IDs and secrets for token management.
- Modify `spotifyRoutes.js` to use Client Credentials Flow for fetching Spotify data.
- Add rate limit handling by switching between multiple Spotify client credentials.
- Retain and isolate OAuth code in `auth.js` for future use without interfering with data fetching.
- Adjust `server.js` to accommodate the new token service and initialize necessary middleware.
- Improve code organization and separation of concerns.